### PR TITLE
Fix some additional issues

### DIFF
--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -10136,11 +10136,12 @@ function NuN_GameTooltip_OnShow(self, tTip)
 	if NuNSettings.ratings then
 		-- NuNSettings.ratings will be nil if this function is called before we've loaded our variables, such as when our cursor happens to hovering over
 		-- something that causes tooltip to be displayed as we're logging in.  (harmless error and can be ignored)
+		-- Wrap the comparison in pcall to handle tainted strings from secure tooltips
 		for idx, value in ipairs(NuNSettings.ratings) do
-			if (locals.currentTooltipTitleString == value) then
+			local success, isMatch = pcall(function() return locals.currentTooltipTitleString == value end);
+			if success and isMatch then
 				pRating = idx;
-				break
-				;
+				break;
 			end
 		end
 	end


### PR DESCRIPTION
Commit 1: fc174aa - Fix combat taint errors by disabling tooltip processing during combat
Problem: Blizzard's 12.0 secure tooltip system marks tooltip data as "secret" (tainted) during combat, causing comparison errors when accessing coordinates or text.
Changes:
- Added InCombatLockdown() check to skip tooltip processing during combat
- Wrapped coordinate comparisons in pcall() to catch taint errors gracefully
- Added nil-safety checks to ensure NuN_GetTipAnchor never returns invalid values
- Added final fallback to guarantee valid anchor strings
Result: Tooltips now disabled during combat (prevents taint), works correctly after combat ends.
---
Commit 2: d6c42c1 - Fix remaining taint error in ratings comparison
Problem: String comparison (currentTooltipTitleString == value) in the ratings loop was still causing taint errors when tooltip text was marked as secret.
Changes:
- Wrapped the string comparison in pcall() to handle tainted tooltip text
- Added explanatory comment
Result: Ratings lookup now gracefully skips tainted comparisons, preventing the "attempt to compare secret value" error.
---
Total: 2 commits, 51 insertions(+), 18 deletions(-) in NotesUNeed.lua