### PR TITLE
Bug Fixes for link-type notes

### DIFF
--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -4693,6 +4693,10 @@ function NuNGNote_WriteNote(noteName)
 		NuNGNoteTitleButtonText:SetText(GetDisplayName(local_player.currentNote.general));
 		NuNGNoteTextBox:Hide();
 		NuNGNoteTitleButton:Show();
+		-- Disable title rename for link-based notes (key format should not be editable)
+		if IsLinkBasedKey(local_player.currentNote.general) then
+			NuNGNoteTitleButton:Disable();
+		end
 		NuNGNoteHeader:SetText(NuNC.NUN_SAVED_NOTE);
 
 		if (NuN_SaveReport) then
@@ -6146,11 +6150,10 @@ end
 ---@return boolean @True if this is a hyperlink-based note key.
 IsLinkBasedKey = function(key)
 	if not key or type(key) ~= "string" then return false; end
-	-- New canonical format: "type:id" where type is one of the known link types
-	if strmatch(key, "^item:%d+$") or strmatch(key, "^spell:%d+$") or
-		strmatch(key, "^achievement:%d+$") or strmatch(key, "^battlepet:%d+$") or
-		strmatch(key, "^currency:%d+$") or strmatch(key, "^talent:%d+$") or
-		strmatch(key, "^enchant:%d+$") then
+	-- Canonical format: "type:id" (e.g. item:12345, spell:67890, mount:111)
+	-- or "type:subtype:id" for journal links (e.g. journal:1:2685).
+	-- Generic pattern covers all current and future WoW link types.
+	if strmatch(key, "^%a+:%d+$") or strmatch(key, "^%a+:%d+:%d+$") then
 		return true;
 	end
 	-- Legacy full-link format (for pre-migration data)
@@ -6174,6 +6177,15 @@ ExtractLinkKey = function(link)
 	if not link or type(link) ~= "string" then return nil, false; end
 	local linkType, linkId = strmatch(link, "|H(%a+):(%d+)");
 	if linkType and linkId and linkId ~= "0" then
+		-- Journal links use journal:journalType:journalID — the first number alone
+		-- is just the subtype (0=Instance, 1=Encounter, 2=Section) and is shared
+		-- across all entries of that subtype. Include the second number as the unique ID.
+		if linkType == "journal" then
+			local journalId = strmatch(link, "|Hjournal:%d+:(%d+)");
+			if journalId then
+				return "journal:" .. linkId .. ":" .. journalId, false;
+			end
+		end
 		return linkType .. ":" .. linkId, false;
 	end
 	-- ID is missing, empty, or zero — fall back to the display name as a plain-text key
@@ -6197,6 +6209,13 @@ BuildDisplayLink = function(link)
 	local linkType, linkId = strmatch(link, "|H(%a+):(%d+)");
 	local suffix = strmatch(link, "(|h%[.-%]|h|r)$");
 	if colorPrefix and linkType and linkId and suffix then
+		-- Journal links need type:subtype:journalID to be a unique, clickable link
+		if linkType == "journal" then
+			local journalId = strmatch(link, "|Hjournal:%d+:(%d+)");
+			if journalId then
+				return colorPrefix .. "|H" .. linkType .. ":" .. linkId .. ":" .. journalId .. suffix;
+			end
+		end
 		return colorPrefix .. "|H" .. linkType .. ":" .. linkId .. suffix;
 	end
 	return link;
@@ -6250,6 +6269,16 @@ local function SimplifyHyperlink(link)
 
 	local key = linkType .. ":" .. linkId;
 	local displayLink = BuildDisplayLink(link);
+
+	-- Journal links: include the second numeric param as the unique identifier.
+	-- journal:1 is just "Encounter" subtype — the encounterID is the second param.
+	if linkType == "journal" then
+		local journalId = strmatch(link, "|Hjournal:%d+:(%d+)");
+		if journalId then
+			key = "journal:" .. linkId .. ":" .. journalId;
+			displayLink = BuildDisplayLink(link);
+		end
+	end
 
 	-- For battlepet, the simplified display link may not work with GameTooltip:SetHyperlink(),
 	-- so we preserve the full original link as the display link.

--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -4565,7 +4565,12 @@ function NuNGNote_WriteNote(noteName)
 		end
 
 		-- Preserve displayLink from existing note before we overwrite the note table
-		local existingDisplayLink = local_player.currentNote.displayLink;
+		-- Only use currentNote.displayLink if the note key is actually link-based;
+		-- otherwise a stale displayLink from a previously deleted item note could leak through.
+		local existingDisplayLink = nil;
+		if IsLinkBasedKey(local_player.currentNote.general) then
+			existingDisplayLink = local_player.currentNote.displayLink;
+		end
 		if not existingDisplayLink then
 			local existingNote = NuNDataANotes[local_player.currentNote.general] or NuNDataRNotes[local_player.currentNote.general];
 			if existingNote and existingNote.displayLink then
@@ -7838,6 +7843,8 @@ function NuNGNote_Delete(noRefresh)
 		elseif (NuNDataANotes[c_note]) then
 			NuNDataANotes[c_note] = nil;
 		end
+		-- Clear stale displayLink so it doesn't contaminate the next note saved
+		local_player.currentNote.displayLink = nil;
 		if (NuN_GTTCheckBox:GetChecked()) then
 			NuN_ClearPinnedTT();
 		end
@@ -12106,7 +12113,7 @@ function NuN_DeleteNote(dType)
 		if (NuNGNoteFrame.fromQuest) then
 			NuNcDeleteLabel:SetText(NuNC.NUN_QUEST_NOTE .. " :\n" .. local_player.currentNote.general);
 		else
-			NuNcDeleteLabel:SetText(NUN_GENERAL_TXT .. " :\n" .. local_player.currentNote.general);
+			NuNcDeleteLabel:SetText(NUN_GENERAL_TXT .. " :\n" .. (local_player.currentNote.displayLink or GetDisplayName(local_player.currentNote.general)));
 		end
 		NuNcDeleteFrame:Show();
 		NuNGNoteTextScroll:ClearFocus();


### PR DESCRIPTION
### Fix Stale displayLink Leaking Across Notes (`5eee792`)

- **Problem:** After deleting an item/link-based note, the `displayLink` from the deleted note persisted in `local_player.currentNote`. Opening and saving a different note would pick up the stale `displayLink`, causing the new note's title to show the deleted item's link and recreating a phantom note entry for the deleted item.
- **Fix:** Clear `local_player.currentNote.displayLink = nil` in `NuNGNote_Delete()` after removing the note data. Added a defense-in-depth guard in `NuNGNote_WriteNote()` that only reads `currentNote.displayLink` when the note key is actually link-based (`IsLinkBasedKey` check).
- Also updated the delete confirmation dialog (`NuN_DeleteNote`) to show the `displayLink` or display name instead of the raw canonical key for item notes.

### Fix Link-Based Note Handling for Mount, Journal, and All Link Types (`3239895`)

- **Problem:** `IsLinkBasedKey` had a hardcoded list of 7 link type prefixes (`item`, `spell`, `achievement`, `battlepet`, `currency`, `talent`, `enchant`) — any unlisted type (e.g. `mount`, `transmogappearance`, `journal`) was not recognized as link-based. This caused mount note titles to revert to the raw key (e.g. `mount:12345`) on save and become editable.
- **Fix:** Replaced the explicit type list with a generic `^%a+:%d+$` pattern, covering all current and future WoW link types.
- **Journal link special handling:** Journal links use the format `journal:journalType:journalID:difficulty` where the first number is just a subtype (0=Instance, 1=Encounter, 2=Section), shared across all entries. Added journal-specific extraction in `ExtractLinkKey`, `SimplifyHyperlink`, and `BuildDisplayLink` to produce unique keys like `journal:1:2685` (subtype + encounterID), difficulty-agnostic. `IsLinkBasedKey` also matches the `type:subtype:id` format.
- **Post-save title button:** Added missing `IsLinkBasedKey` check in `NuNGNote_WriteNote` after save to disable the title button for link-based notes, matching the existing checks in `NuN_ShowTitledGNote` and `NuN_ShowSavedGNote`.