### PR TITLE
More fixes for the people

### DIFF
--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -2693,10 +2693,13 @@ function NuNF.NUN_InitializeDelayedHooks()
 	-- hook into the chat window hyperlink clicks
 	-- In modern WoW (11.x+), chat frames capture the OnHyperlinkClick handler at creation
 	-- time, so replacing the global ChatFrame_OnHyperlinkShow has no effect. Instead, we:
-	-- 1. Pre-hook SetItemRef to intercept NuN: custom links (prevents "unknown link type" errors)
-	-- 2. HookScript("OnHyperlinkClick") on each chat frame for modifier-key note creation
-	NuNHooks.NuNOriginal_SetItemRef = SetItemRef;
-	SetItemRef = NuN_SetItemRef_PreHook;
+	-- 1. HookScript("OnHyperlinkClick") on each chat frame for ALL NuN hyperlink handling
+	--    (NuN: custom links, modifier-key note creation, etc.)
+	-- 2. hooksecurefunc SetItemRef for debug logging only (does NOT replace the global,
+	--    to avoid tainting the secure execution context for context menus)
+	hooksecurefunc("SetItemRef", function(link, text, button)
+		nun_msgf(">>SetItemRef(post-hook) - link:%s  text:%s  btn:%s", DecodeHyperlink(link), DecodeHyperlink(text), tostring(button));
+	end);
 
 	for _, frameName in pairs(CHAT_FRAMES) do
 		local frame = _G[frameName];
@@ -6676,47 +6679,6 @@ function NuN_GetColoredName(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg
 	return arg2;
 end
 
--- SetItemRef pre-hook: intercepts NuN: custom hyperlinks before WoW's SetItemRef
--- sees them, preventing "unknown link type" errors. All other link types pass through
--- to the original SetItemRef unmodified.
-function NuN_SetItemRef_PreHook(link, text, button)
-	nun_msgf(">>NuN_SetItemRef_PreHook - link:%s  text:%s  btn:%s", DecodeHyperlink(link), DecodeHyperlink(text), tostring(button));
-
-	-- Only intercept NuN: custom links; everything else passes through to the original
-	if (strsub(link, 1, 3) == "NuN") or (strsub(link, 1, 4) == ":NuN") then
-		if (NuNSettings[local_player.realmName].modifier == "on") then
-			if (receiptPending) and (locals.NuN_Receiving.type == "General") then
-				return; -- don't interfere with note receipt
-			end
-			local _name;
-			if (strsub(link, 1, 4) == ":NuN") then
-				_name = strsub(link, 6); -- skip ":NuN:"
-			else
-				_name = strsub(link, 5); -- skip "NuN:"
-			end
-			if (_name and (strlen(_name) > 0)) then
-				local uid = strfind(_name, ":");
-				if (uid) then
-					_name = strsub(_name, 1, uid - 1);
-				end
-				if (locals.NuNDataPlayers[_name]) then
-					NuN_ShowSavedNote(_name);
-				else
-					NuN_CreateContact(_name, local_player.factionName);
-				end
-				if (DEFAULT_CHAT_FRAME.editBox) then
-					DEFAULT_CHAT_FRAME.editBox:Hide();
-				end
-			end
-		end
-		-- Always return here for NuN: links — do NOT call original SetItemRef
-		return;
-	end
-
-	-- Not a NuN link — pass through to original SetItemRef
-	NuNHooks.NuNOriginal_SetItemRef(link, text, button);
-end
-
 -- Post-hook for chat frame OnHyperlinkClick: handles modifier-key note creation
 -- for player links and item/battlepet/currency links. Runs AFTER WoW's default
 -- handler has already processed the click (so tooltips are already visible).
@@ -6729,8 +6691,28 @@ function NuN_OnHyperlinkClick_PostHook(chatframe, link, text, button)
 	if (receiptPending) and (locals.NuN_Receiving.type == "General") then
 		return;
 	end
-	-- NuN: links are already handled by SetItemRef pre-hook; skip them here
+	-- NuN: custom links — handle directly here (no longer intercepted by SetItemRef pre-hook)
 	if (strsub(link, 1, 3) == "NuN") or (strsub(link, 1, 4) == ":NuN") then
+		local _name;
+		if (strsub(link, 1, 4) == ":NuN") then
+			_name = strsub(link, 6); -- skip ":NuN:"
+		else
+			_name = strsub(link, 5); -- skip "NuN:"
+		end
+		if (_name and (strlen(_name) > 0)) then
+			local uid = strfind(_name, ":");
+			if (uid) then
+				_name = strsub(_name, 1, uid - 1);
+			end
+			if (locals.NuNDataPlayers[_name]) then
+				NuN_ShowSavedNote(_name);
+			else
+				NuN_CreateContact(_name, local_player.factionName);
+			end
+			if (DEFAULT_CHAT_FRAME.editBox) then
+				DEFAULT_CHAT_FRAME.editBox:Hide();
+			end
+		end
 		return;
 	end
 
@@ -6829,8 +6811,7 @@ function NuN_OnHyperlinkClick_PostHook(chatframe, link, text, button)
 end
 
 -- LEGACY: kept for reference but no longer used as the global ChatFrame_OnHyperlinkShow replacement.
--- The hook is now split into NuN_SetItemRef_PreHook (for NuN: links) and
--- NuN_OnHyperlinkClick_PostHook (for modifier-key note creation on chat frames).
+-- All NuN hyperlink handling is now done via NuN_OnHyperlinkClick_PostHook (HookScript on each chat frame).
 --[[ 
 function NuN_ChatFrameOnHyperlinkShow(chatframe, link, text, buttonName)
 	local processedByNuN = NuNNew_SetItemRef(chatframe, link, text, buttonName);

--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -653,9 +653,7 @@ StaticPopupDialogs["NUN_CHANGE_RATING_ONE"] = {
 				UIDropDownMenu_SetText(NuNDropDown_PlayerRating, text);
 			end
 			NuNSettings.ratings[chosenRating] = text;
-			if (NuNSettings[local_player.realmName].rightClickMenu == true) then
-				NuN_SetupRatings();
-			end
+			NuN_SetupRatings();
 			local r = 0;
 			if (NuN_BLCheckBox:GetChecked()) then
 				r = 1;
@@ -677,9 +675,7 @@ StaticPopupDialogs["NUN_CHANGE_RATING_ONE"] = {
 				UIDropDownMenu_SetText(NuNDropDown_PlayerRating, text);
 			end
 			NuNSettings.ratings[chosenRating] = text;
-			if (NuNSettings[local_player.realmName].rightClickMenu == true) then
-				NuN_SetupRatings();
-			end
+			NuN_SetupRatings();
 			local r = 0;
 			if (NuN_BLCheckBox:GetChecked()) then
 				r = 1;
@@ -3232,19 +3228,6 @@ function NuN_CmdLine(option, parm1, pList)
 		elseif (switch == "-tt") then
 			NuN_ToggleToolTips();
 
-			-- Enable Right Click Menu functionality
-		elseif (switch == "-righton") then
-			if (NuNSettings[local_player.realmName].rightClickMenu == false) then
-				NuN_SetupRatings();
-			end
-			NuNSettings[local_player.realmName].rightClickMenu = true;
-			NuN_Message(NUN_PRATING);
-
-			-- Disable Right Click Menu functionality
-		elseif (switch == "-rightoff") then
-			NuNSettings[local_player.realmName].rightClickMenu = false;
-			NuN_Message("Right-click menu disabled.");
-
 			-- Create Alliance / Horde Contact Notes without validating Player exists
 		elseif ((switch == "-ca") or (switch == "-ch")) then
 			if ((receiptPending) and (locals.NuN_Receiving.type == "Contact")) then
@@ -4844,13 +4827,8 @@ local function OnNotesUNeedFullyLoaded(self, ...)
 	-- MapNotes related functions linking NuN to Map Notes
 	NuN_IndexAll();
 
-	-- Unit Right Click Menu changes
-	if (NuNSettings[local_player.realmName].rightClickMenu == nil) then
-		NuNSettings[local_player.realmName].rightClickMenu = true;
-	end
-	if (NuNSettings[local_player.realmName].rightClickMenu == true) then
-		NuN_SetupRatings();
-	end
+	-- Initialize player rating variables
+	NuN_SetupRatings();
 
 	-- Variables loaded - GUILD ROSTER UPDATE
 	-- Ensure Guild Roster Update, if the guild UI is loaded already; otherwise, do this when that addon loads
@@ -13711,7 +13689,7 @@ function NuN_MassDelete()
 	--	end
 end
 
--- Set up the Unit Right Click menu options for recording Player Rating : will create a note if necesary
+-- Initialize player rating variables from saved settings (or defaults)
 function NuN_SetupRatings()
 
 	-- Player specified ratings - MUST create Brand New arrays so that Originals are not corrupted by changes and are available to "Reset" the values
@@ -13755,201 +13733,6 @@ function NuN_SetupRatings()
 		NUN_PR_TWOSTAR = NuNSettings.ratings[24];
 		NUN_PR_ONESTAR = NuNSettings.ratings[25];
 		NUN_PR___ = NuNSettings.ratings[26];
-	end
-
-	-- WoW 11.0 Menu.ModifyMenu hook: Register once, check rightClickMenu at runtime
-	if not NuN_State.contextMenuHookRegistered then
-		NuN_State.contextMenuHookRegistered = true;
-
-		-- All player-related menu tags we want to hook into.
-		-- Menu.ModifyMenu tags are "MENU_UNIT_" .. the tag registered with UnitPopupManager.
-		local menuTags = {
-			"MENU_UNIT_PLAYER",			-- right-click another player in the world
-			"MENU_UNIT_PARTY",			-- party member
-			"MENU_UNIT_RAID_PLAYER",	-- raid member
-			"MENU_UNIT_FRIEND",			-- friends list entry (online)
-			"MENU_UNIT_FRIEND_OFFLINE",	-- friends list entry (offline)
-			"MENU_UNIT_GUILD",			-- guild roster entry (online)
-			"MENU_UNIT_GUILD_OFFLINE",	-- guild roster entry (offline)
-			"MENU_UNIT_BN_FRIEND",		-- Battle.net friend (online)
-			"MENU_UNIT_BN_FRIEND_OFFLINE", -- Battle.net friend (offline)
-			"MENU_UNIT_COMMUNITIES_WOW_MEMBER",		-- communities member
-			"MENU_UNIT_COMMUNITIES_GUILD_MEMBER",	-- guild communities member
-			"MENU_UNIT_CHAT_ROSTER",	-- chat channel roster
-			"MENU_UNIT_ENEMY_PLAYER",	-- enemy player
-			"MENU_UNIT_TARGET",			-- generic target (can be a player)
-		};
-
-		for _, tag in ipairs(menuTags) do
-			Menu.ModifyMenu(tag, function(ownerRegion, rootDescription, contextData)
-				-- Check if feature is enabled at runtime (allows toggle without ReloadUI)
-				if not NuNSettings[local_player.realmName].rightClickMenu then
-					return;
-				end
-
-			-- Extract the player name from contextData
-			local _name = contextData.name;
-
-			-- WoW 12.0 Secret Values: contextData.name may be secret for restricted units.
-			-- Must check BEFORE any boolean test or comparison on _name.
-			if issecretvalue and issecretvalue(_name) then return; end
-
-			if not _name or _name == "" then return; end
-
-				-- Capture unit token and GUID for data mining
-				local unit = contextData.unit;
-				local guid = contextData.guid;
-				local server = contextData.server;
-
-				-- Chat right-click: no guid in contextData, but lineID is available.
-				-- Use C_ChatInfo.GetChatLineSenderGUID to recover the GUID.
-				if not guid and contextData.lineID then
-					guid = C_ChatInfo.GetChatLineSenderGUID(contextData.lineID);
-				end
-
-				-- Handle cross-realm: append server name if different realm
-				if server and server ~= "" and server ~= local_player.realmName then
-					if unit then
-						local fullName = GetUnitName(unit, true);
-						-- WoW 12.0 Secret Values: skip if unit name is secret.
-						if fullName and (not issecretvalue or not issecretvalue(fullName)) then
-							_name = fullName;
-						end
-					else
-						_name = _name .. "-" .. server;
-					end
-				end
-
-				-- Helper: apply clubMemberInfo enrichment after a note is created/displayed.
-				-- contextData from guild roster (MENU_UNIT_COMMUNITIES_GUILD_MEMBER) provides
-				-- a clubMemberInfo table with guild rank, notes, class, race, etc.
-				local function ApplyClubMemberInfo()
-					local cmi = contextData.clubMemberInfo;
-					if not cmi then return; end
-
-					-- Guild name: clubMemberInfo doesn't carry the guild name directly,
-					-- but for COMMUNITIES_GUILD_MEMBER the target is in *our* guild.
-					local lgName = contextData.clubInfo and contextData.clubInfo.name;
-					if not lgName then
-						lgName = GetGuildInfo("player");
-					end
-
-					if lgName and lgName ~= "" then
-						contact.guild = lgName;
-
-						local bttnHeadingText1 = _G["NuNTitleButton1ButtonTextHeading"];
-						local bttnDetailText1 = _G["NuNInforButton1ButtonTextDetail"];
-						local bttnHeadingText2 = _G["NuNTitleButton2ButtonTextHeading"];
-						local bttnDetailText2 = _G["NuNInforButton2ButtonTextDetail"];
-
-						if bttnHeadingText1:GetText() == NUN_DFLTHEADINGS[1] then
-							bttnDetailText1:SetText(lgName);
-							locals.bttnChanges[6] = lgName;
-						end
-
-						if cmi.guildRank and bttnHeadingText2:GetText() == NUN_DFLTHEADINGS[2] then
-							local lgRankTxt;
-							if cmi.guildRankOrder == 0 then
-								lgRankTxt = "GM : " .. cmi.guildRank;
-							else
-								lgRankTxt = (cmi.guildRankOrder or "?") .. " : " .. cmi.guildRank;
-							end
-							bttnDetailText2:SetText(lgRankTxt);
-							locals.bttnChanges[7] = lgRankTxt;
-						end
-					end
-
-					-- Guild note and officer note (for display in NuN's guild note fields)
-					if cmi.memberNote then
-						gNote = cmi.memberNote;
-					end
-					if cmi.officerNote then
-						gOfficerNote = cmi.officerNote;
-					end
-				end
-
-				-- Add divider and NuN section header
-				rootDescription:CreateDivider();
-				rootDescription:CreateTitle(NUN_POPUP_TITLE);
-
-				-- "Open Note" button
-				rootDescription:CreateButton(NUN_POPUP_TOGGLE, function()
-					if locals.NuNDataPlayers[_name] then
-						NuN_ShowSavedNote(_name);
-					elseif unit and unit == "target" then
-						NuN_FromTarget(false);
-					elseif unit then
-						NuN_NewContact(unit);
-					else
-						NuN_CreateContact(_name, local_player.factionName, guid);
-					end
-					ApplyClubMemberInfo();
-				end);
-
-				-- Player Rating submenu (only if ratings are configured)
-				if NuNSettings.ratings then
-					local ratingsMenu = rootDescription:CreateButton("Player Rating");
-					local currentRating = nil;
-					if locals.NuNDataPlayers[_name] and locals.NuNDataPlayers[_name].prating then
-						currentRating = locals.NuNDataPlayers[_name].prating;
-					end
-
-					for i = 1, maxRatings, 1 do
-						local ratingText = NuNSettings.ratings[i];
-						if ratingText then
-							local ratingIndex = i;
-							local ratingButton = ratingsMenu:CreateRadio(ratingText,
-								function() return currentRating == ratingIndex; end,
-								function()
-									-- Ensure note exists before assigning rating
-									if not locals.NuNDataPlayers[_name] then
-										if unit and unit == "target" then
-											NuN_FromTarget(true);
-										elseif unit then
-											NuN_NewContact(unit);
-											ApplyClubMemberInfo();
-											NuN_WriteNote();
-											HideNUNFrame();
-										else
-											NuN_CreateContact(_name, local_player.factionName, guid);
-											ApplyClubMemberInfo();
-											NuN_WriteNote();
-											HideNUNFrame();
-										end
-									end
-
-									-- Assign the rating
-									if locals.NuNDataPlayers[_name] then
-										locals.NuNDataPlayers[_name].prating = ratingIndex;
-										pRating = ratingIndex;
-
-										-- Update the UI if this player's note is currently open
-										if _name == local_player.currentNote.unit then
-											locals.dropdownFrames.ddPRating = ratingIndex;
-											contact.prating = NuNSettings.ratings[ratingIndex];
-											UIDropDownMenu_SetSelectedID(NuNDropDown_PlayerRating, ratingIndex);
-											UIDropDownMenu_SetText(NuNDropDown_PlayerRating, contact.prating);
-										end
-
-										-- BlackList integration
-										if BlackList then
-											NuN_BlackList(_name, ratingIndex);
-										end
-									end
-								end
-							);
-							-- Add tooltip text for the rating
-							if NuNSettings.ratingsT and NuNSettings.ratingsT[i] then
-								ratingButton:SetTooltip(function(tooltip, elementDescription)
-									GameTooltip_SetTitle(tooltip, ratingText);
-									GameTooltip_AddNormalLine(tooltip, NuNSettings.ratingsT[i]);
-								end);
-							end
-						end
-					end
-				end
-			end);
-		end
 	end
 end
 

--- a/NotesUNeed/NotesUNeed.lua
+++ b/NotesUNeed/NotesUNeed.lua
@@ -2682,6 +2682,21 @@ function NuNF.NuN_InitialiseSavedVariables()
 	end
 end
 
+-- Hook the CommunitiesFrame chat message frame (guild chat in J panel).
+-- This frame is NOT in the CHAT_FRAMES list and is created by the load-on-demand
+-- Blizzard_Communities addon, so we must hook it when it becomes available.
+-- Safe to call multiple times — will only hook once.
+function NuNF.NuN_HookCommunitiesChat()
+	if CommunitiesFrame and CommunitiesFrame.Chat and CommunitiesFrame.Chat.MessageFrame then
+		local msgFrame = CommunitiesFrame.Chat.MessageFrame;
+		if not msgFrame.NuNHooked then
+			msgFrame:HookScript("OnHyperlinkClick", NuN_OnHyperlinkClick_PostHook);
+			msgFrame.NuNHooked = true;
+			nun_msgf("NuN: Hooked CommunitiesFrame.Chat.MessageFrame for OnHyperlinkClick");
+		end
+	end
+end
+
 function NuNF.NUN_InitializeDelayedHooks()
 	--[[
 	rather than hooking container frames only, hook the underlying function that handles modified clicks for all ItemButtonTemplate-derived frame types...
@@ -2698,7 +2713,7 @@ function NuNF.NUN_InitializeDelayedHooks()
 	-- 2. hooksecurefunc SetItemRef for debug logging only (does NOT replace the global,
 	--    to avoid tainting the secure execution context for context menus)
 	hooksecurefunc("SetItemRef", function(link, text, button)
-		nun_msgf(">>SetItemRef(post-hook) - link:%s  text:%s  btn:%s", DecodeHyperlink(link), DecodeHyperlink(text), tostring(button));
+		nun_msgf(">>SetItemRef(post-hook) - link:%s  text:%s  btn:%s", tostring(link), tostring(text), tostring(button));
 	end);
 
 	for _, frameName in pairs(CHAT_FRAMES) do
@@ -2719,6 +2734,10 @@ function NuNF.NUN_InitializeDelayedHooks()
 			end
 		end
 	end);
+
+	-- Hook CommunitiesFrame chat (guild chat in J panel) — this is NOT in CHAT_FRAMES.
+	-- Blizzard_Communities is a load-on-demand addon, so the frame may not exist yet.
+	NuNF.NuN_HookCommunitiesChat();
 
 	-- this is actually a post-hook, in that we will not interfere with the normal operation of the game.  Unfortunately, since the World of Warcraft's hooksecurefunc() functionality
 	-- doesn't provide any way to determine what the original function's return value was, we have to pre-hook and call itselves.  If it returns false, then we'll attempt to process
@@ -5055,6 +5074,9 @@ function NuN_OnEvent(self, event, ...)
 		elseif (arg1 == "Prat-3.0") then
 			nun_msgf(" .. registering prat chat filters.");
 			NuN_RegisterChatFilter();
+		elseif (arg1 == "Blizzard_Communities") then
+			-- CommunitiesFrame just became available — hook its chat for alt-click support
+			NuNF.NuN_HookCommunitiesChat();
 		end
 		-- REMOVE: This is no longer needed
 		-- Get Delayed Who Event information on players
@@ -6720,7 +6742,11 @@ function NuN_OnHyperlinkClick_PostHook(chatframe, link, text, button)
 		local _name;
 		if strsub(link, 1, 9) == "HBNplayer" then
 			-- BNet player links — currently unhandled, same as original code
+		elseif strsub(link, 1, 16) == "playerCommunity:" then
+			-- Community (guild) chat links: "playerCommunity:Name-Realm:clubId:streamId:epoch"
+			_name = strsub(link, 17); -- skip "playerCommunity:"
 		else
+			-- Standard player links: "player:Name-Realm:..."
 			_name = strsub(link, 8);
 		end
 		if (_name and (strlen(_name) > 0)) then


### PR DESCRIPTION
This pull request refactors how NotesUNeed handles chat hyperlink clicks and player rating setup, streamlining support for new WoW chat frames and simplifying configuration for right-click menus. The most important changes are grouped below:

Fixes #22 

**Chat hyperlink handling improvements:**

* Replaces the previous SetItemRef pre-hook with a post-hook on each chat frame's `OnHyperlinkClick`, consolidating all custom link and modifier-key note creation logic into `NuN_OnHyperlinkClick_PostHook`. This ensures compatibility with modern WoW chat frame creation and avoids tainting secure context menus. [[1]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L6701-R6717) [[2]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L2700-R2717)
* Adds explicit support for hooking the CommunitiesFrame chat (guild chat in the J panel), which is not part of the standard chat frame list and is loaded on demand. The hook is registered both at startup and when the `Blizzard_Communities` addon loads. [[1]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303R2685-R2699) [[2]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303R2738-R2741) [[3]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303R5077-R5079)
* Updates hyperlink parsing to handle new link formats, including community player links in guild chat.

**Player rating and right-click menu changes:**

* Removes the toggle for the right-click menu feature and now always initializes player ratings on load, simplifying configuration and ensuring consistent menu availability. [[1]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L4847-L4853) [[2]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L3235-L3247)
* Refactors `NuN_SetupRatings` to focus solely on initializing player rating variables, removing the dynamic menu hook registration logic. [[1]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L13714-R13699) [[2]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L13759-L13953)

**Miscellaneous:**

* Cleans up legacy comments and removes obsolete code related to previous hyperlink hook strategies.
* Simplifies logic for updating player ratings in the popup dialog, removing unnecessary conditional checks. [[1]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L656-L658) [[2]](diffhunk://#diff-f8e12461531e75c890b5c05092e5af5ab9f969e65d37bbd4a9ee6db7aa620303L680-L682)